### PR TITLE
feat: Support Dynamic MODEL_DIR (#9)

### DIFF
--- a/airllm.sh
+++ b/airllm.sh
@@ -7,7 +7,7 @@ IMAGE_NAME="airllm-local"
 CONTAINER_NAME="airllm-server"
 HOST_PORT=11434
 CONTAINER_PORT=11434
-MODEL_DIR="$(pwd)/models"  # local models folder
+MODEL_DIR="${MODEL_DIR:-$(pwd)/models}"  # use environment variable if set, otherwise default to local
 # --------------------------
 
 # Function to stop and remove container


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #9

### Description of Changes
Updated `MODEL_DIR` in `airllm.sh` to allow configuration via environment variables while safely defaulting to `$(pwd)/models`.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant): `MODEL_DIR=/mnt/nvme_ram ./airllm.sh start`
- What environments were used: local bash terminal

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [ ] Tests cover change

### Related Issues
- Closes #9
