### PR TITLE
[TASK] Remove check-agents.sh lint requirement from workflow governance (#20)

### DIFF
--- a/ai/governance/workflow-governance.md
+++ b/ai/governance/workflow-governance.md
@@ -29,5 +29,4 @@ If automated PRs bypass issue-first:
 
 ## Lint Requirement
 If modifying agent-*.md, skill-*.md, or ai-report-*.md:
-Run:
-    ./scripts/check-agents.sh
+MD files are the sole governance artifacts. No external script is required.


### PR DESCRIPTION
## Summary

Removes the reference to `./scripts/check-agents.sh` from the Lint Requirement section of `ai/governance/workflow-governance.md`.

The script does not exist and should not be required. MD files are the sole governance artifacts for agent/skill/report file validation.

## Changes

- `ai/governance/workflow-governance.md`: Replaced shell script run instruction with a plain statement that MD files suffice.

Fixes #20