### PR TITLE
[TASK] Require assignees on all issues and PRs in workflow governance (#22)

### DIFF
--- a/ai/governance/workflow-governance.md
+++ b/ai/governance/workflow-governance.md
@@ -11,6 +11,7 @@ All changes must follow Issue-First Development.
 - Issue and PR titles must use uppercase type in brackets: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
 - PR must reference issue
 - Matching labels between Issue and PR
+- All issues and PRs must have at least one assignee
 - Plain text formatting only (ASCII, markdown checkboxes)
 - Issue type must be Bug, Feature, or Task
 


### PR DESCRIPTION
## Summary

The `workflow-governance.md` did not mandate that issues and PRs must have an assignee. This adds it as an explicit non-negotiable constraint to ensure clear ownership of every work item.

## Changes

- `ai/governance/workflow-governance.md`: Added: *All issues and PRs must have at least one assignee* to the Non-Negotiable Constraints list.

Fixes #22