### PR TITLE
[BUG] models/ directory not fully covered by .gitignore (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ docker-compose.override.yml
 # Sensitive / config files
 config.json
 
-# Models folder structure
-models/*.safetensors
+# Models folder - ignore all model artefacts, preserve folder structure
+models/
+!models/.gitkeep


### PR DESCRIPTION
## Summary

Only `models/*.safetensors` was excluded from git, meaning other model file types (.bin, .gguf, tokenizer JSONs etc.) could be accidentally committed.

## Changes

- `models/.gitkeep`: Added to preserve the folder in git

Fixes #24