### PR TITLE
[BUG] requirements.txt specifies Pydantic v2 but server uses v1 API (#25)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scipy>=1.11.4
 # FastAPI server dependencies
 fastapi>=0.104.0
 uvicorn>=0.24.0
-pydantic>=2.4.0
+pydantic>=1.10,<2.0
 
 # Optional: git for HF hub installs
 gitpython>=3.1.36


### PR DESCRIPTION
## Summary

`requirements.txt` specified `pydantic>=2.4.0` but the `Dockerfile` pins `pydantic==1.10.12`. These are incompatible — Pydantic v2 has breaking API changes. `server.py` uses v1-style `BaseModel` so the Dockerfile is correct; requirements.txt was wrong.

## Changes

- `requirements.txt`: Changed `pydantic>=2.4.0` to `pydantic>=1.10,<2.0`

Fixes #25