### PR TITLE
[TASK] Add config.json.example to document expected schema (#26)

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,3 @@
+{
+  "model_name": "Qwen/Qwen2.5-Coder-7B-Instruct"
+}


### PR DESCRIPTION
## Summary

`config.json` is referenced in the README and used by `airllm.sh` but is gitignored and no example was provided, leaving contributors without a schema reference.

## Changes

- `config.json.example` [NEW]: Documents the `model_name` field expected by the server

Fixes #26