### PR TITLE
[TASK] Modernise server.py: lifespan context manager and /v1/models endpoint (#28)

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ import json
 import logging
 import asyncio
 import torch
+from contextlib import asynccontextmanager
 from threading import Thread
 from typing import List, Optional
 from fastapi import FastAPI, Request
@@ -17,7 +18,15 @@ from transformers import (
 # --- Logging & Configuration ---
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-app = FastAPI(title="AirLLM NVMe Optimized Server")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Load the model and launch the inference worker on startup."""
+    load_model()
+    asyncio.create_task(inference_worker())
+    yield
+
+app = FastAPI(title="AirLLM NVMe Optimized Server", lifespan=lifespan)
 
 # --- Global State ---
 request_queue = asyncio.Queue()
@@ -163,11 +172,18 @@ async def chat_completions(request: ChatCompletionRequest):
 
     return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
-@app.on_event("startup")
-async def startup_event():
-    load_model()
-    # Launch the persistent worker task
-    asyncio.create_task(inference_worker())
+@app.get("/v1/models")
+async def list_models():
+    """OpenAI-compatible models list stub."""
+    model_id = MODEL_PATH if MODEL_PATH != "/app/models" else "local-model"
+    return {
+        "object": "list",
+        "data": [{
+            "id": model_id,
+            "object": "model",
+            "owned_by": "airllm",
+        }]
+    }
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary

Two related server.py improvements bundled together:

1. `@app.on_event("startup")` is deprecated in FastAPI/Starlette — migrated to the `lifespan` asynccontextmanager pattern.
2. Added `GET /v1/models` stub returning the active model in OpenAI list format so Continue and other compatible clients can connect without silent failures.

## Changes

- `server.py`: Added `from contextlib import asynccontextmanager`
- `server.py`: Replaced `@app.on_event("startup")` with `@asynccontextmanager` lifespan function passed to `FastAPI(lifespan=...)`
- `server.py`: Added `GET /v1/models` endpoint

Fixes #28