### PR TITLE
[BUG] airllm.sh restart does not rebuild image and container has no restart policy (#29)

### DIFF
--- a/airllm.sh
+++ b/airllm.sh
@@ -46,6 +46,7 @@ run_container() {
     echo "🚀 Starting container $CONTAINER_NAME..."
     docker run --gpus all -d \
         --name $CONTAINER_NAME \
+        --restart unless-stopped \
         -p $HOST_PORT:$CONTAINER_PORT \
         -v $MODEL_DIR:/app/models \
         $IMAGE_NAME
@@ -80,11 +81,16 @@ case "$1" in
         stop_container
         run_container
         ;;
+    rebuild)
+        stop_container
+        build_image
+        run_container
+        ;;
     logs)
         show_logs
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|logs}"
+        echo "Usage: $0 {start|stop|restart|rebuild|logs}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

Two reliability issues with `airllm.sh` have been fixed:

1. The `restart` command called `stop_container` + `run_container` but skipped `build_image`. If `server.py` was modified, `restart` silently served a stale image.
2. The `docker run` command had no `--restart` policy, meaning the container could not auto-recover from crashes or system reboots.

## Changes

- `airllm.sh`: Added `--restart unless-stopped` to the `docker run` call.
- `airllm.sh`: Added a explicit `rebuild` command that stops, rebuilds, and restarts the container.

Fixes #29