### PR TITLE
[BUG] Missing asynccontextmanager import in server.py (#36)

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ import os
 import logging
 import asyncio
 import torch
+from contextlib import asynccontextmanager
 from pathlib import Path
 from threading import Thread
 from typing import List, Optional


### PR DESCRIPTION
## Summary

`server.py` crashed on startup with `NameError: name 'asynccontextmanager' is not defined` due to a missing import.

## Changes

- `server.py`: Added `from contextlib import asynccontextmanager`

Fixes #36