### PR TITLE
[TASK] Standardize PR and Issue body formatting in governance (#38)

### DIFF
--- a/ai/governance/workflow-governance.md
+++ b/ai/governance/workflow-governance.md
@@ -9,11 +9,35 @@ All changes must follow Issue-First Development.
 - No branch without issue number
 - Conventional commit format required
 - Issue and PR titles must use uppercase type in brackets: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
-- PR must reference issue
+- PR must reference issue at the bottom (e.g., `Fixes #123`)
 - Matching labels between Issue and PR
 - All issues and PRs must have at least one assignee
 - Plain text formatting only (ASCII, markdown checkboxes)
 - Issue type must be Bug, Feature, or Task
+
+## Standard Formatting Templates
+All Issues and PRs must follow a consistent markdown body structure. When using CLI tools, do not use literal `\n` escape characters in inline strings as they break formatting; instead, use interactive editors or multiline string passing.
+
+### Issue Body Template
+```markdown
+## Description
+[Clear description of the bug, feature, or task]
+
+## Context/Additional Information
+[Any relevant background, screenshots, or logs]
+```
+
+### Pull Request Body Template
+```markdown
+## Summary
+[Brief description of the changes being made]
+
+## Changes
+- [File/Component]: [What was changed]
+- [File/Component]: [What was changed]
+
+Fixes #[Issue Number]
+```
 
 ## Label Taxonomy Rules
 - Task is an issue type, not a label


### PR DESCRIPTION
## Summary
The governance document now includes explicit formatting templates for Issues and Pull Requests.

## Changes
- `ai/governance/workflow-governance.md`: Added standard body templates and instructions to avoid literal `\n` escapes when using CLI tools.

Fixes #38