### PR TITLE
[BUG] config.json is not mounted in airllm.sh docker run command (#40)

### DIFF
--- a/airllm.sh
+++ b/airllm.sh
@@ -44,11 +44,19 @@ build_image() {
 # Function to run the container
 run_container() {
     echo "🚀 Starting container $CONTAINER_NAME..."
+    
+    CONFIG_MOUNT=""
+    if [ -f "config.json" ]; then
+        CONFIG_MOUNT="-v $(pwd)/config.json:/app/config.json:ro"
+        echo "📄 Found config.json, mounting to container"
+    fi
+    
     docker run --gpus all -d \
         --name $CONTAINER_NAME \
         --restart unless-stopped \
         -p $HOST_PORT:$CONTAINER_PORT \
         -v $MODEL_DIR:/app/models \
+        $CONFIG_MOUNT \
         $IMAGE_NAME
     if [ $? -eq 0 ]; then
         echo "✅ Container $CONTAINER_NAME is running"


### PR DESCRIPTION
## Summary
The local `config.json` is not passed to the container at launch, breaking custom model configurations.

## Changes
- `airllm.sh`: Added an existence check for `config.json` that populates a `CONFIG_MOUNT` argument passed to the `docker run` command.

Fixes #40