### PR TITLE
[TASK] Add startup delay warnings to manage user expectations (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ This will build the Docker image (if not already built) and run the container on
 ./airllm.sh start
 ```
 
+> [!WARNING]
+> **Startup Delay**: Loading a 7B model from NVMe into memory with 4-bit quantization takes **5 to 7 minutes** on consumer hardware. During this time, the API (port 11434) will refuse connections (e.g. from the Continue CLI). Use `./airllm.sh logs` and wait for the message `Application startup complete` before trying to connect.
+
 **Stop the Server:**
 ```bash
 ./airllm.sh stop

--- a/airllm.sh
+++ b/airllm.sh
@@ -60,7 +60,13 @@ run_container() {
         $IMAGE_NAME
     if [ $? -eq 0 ]; then
         echo "✅ Container $CONTAINER_NAME is running"
-        echo "📡 Access API at http://localhost:$HOST_PORT/"
+        echo ""
+        echo "⚠️  IMPORTANT: The server is loading the 7B parameter model from NVMe into memory."
+        echo "⏳ This process takes roughly 5 to 7 minutes on consumer hardware."
+        echo "🚫 The API will NOT accept connections (e.g. from Continue CLI) until loading completes."
+        echo "🔬 Run './airllm.sh logs' and wait for: 'Application startup complete.'"
+        echo ""
+        echo "📡 Access API at http://localhost:$HOST_PORT/ once loaded."
     else
         echo "❌ Failed to start container"
         exit 1


### PR DESCRIPTION
## Summary
To prevent users from mistakenly thinking the app or the Continue CLI is broken when testing the connection right after `airllm.sh start`, this PR adds prominent warnings setting the expectation that loading the model takes several minutes.

## Changes
- `airllm.sh`: Added explicit `echo` statements after the container run command notifying the user of the 5-7 min delay and instructing them to wait for `Application startup complete`.
- `README.md`: Added a `GitHub Alert` note in the Usage section with the exact same expectation management.

Fixes #42